### PR TITLE
Turn off auto-shooting by default

### DIFF
--- a/src/client/html/index.html
+++ b/src/client/html/index.html
@@ -24,7 +24,7 @@
             <input type="text" id="username-input" placeholder="Enter a name..." />
             <button id="play-button"><strong>Play!</strong></button>
             
-        <label class="switch"><input type="checkbox" id="togBtn"><div class="slider round">
+        <label class="switch"><input type="checkbox" id="togBtn" checked><div class="slider round">
             <span class="off"><strong>Auto</strong></span><span class="on"> <strong>Click</strong></span><!--END--></div></label>
         </div>
     </div>


### PR DESCRIPTION
Set the shooting mode toggle to be checked by default, which enables click-to-shoot mode instead of auto-shooting mode. Players can still toggle this setting in the game menu if they prefer auto-shooting.